### PR TITLE
Automatically Create Cache File and Keys Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,6 @@ Hacked together really quick - making it public as now I use a stock ROM.
    GITHUB_TOKEN=your_personal_access_token
    ```
 
-4. Create a directory named `keys` in the project root to store the downloaded XML files. Also, create a cache file to store the cache for the URLs already checked:
-   ```sh
-   mkdir keys; touch cache.txt
-   ```
-
 ## Usage
 
 1. Run the main script to scrape `keybox.xml` files from GitHub, validate them, and save them:

--- a/keyboxer.py
+++ b/keyboxer.py
@@ -80,6 +80,9 @@ def fetch_file_content(url: str) -> bytes:
         raise RuntimeError(f"Failed to download {url}")
 
 
+# Create directory for storing keys
+os.makedirs(save, exist_ok=True)
+
 # Fetch all pages
 page = 1
 while fetch_and_process_results(page):

--- a/keyboxer.py
+++ b/keyboxer.py
@@ -29,7 +29,7 @@ headers = {
 
 save = Path(__file__).resolve().parent / "keys"
 cache_file = Path(__file__).resolve().parent / "cache.txt"
-cached_urls = set(open(cache_file, "r").readlines())
+cached_urls = set(open(cache_file, "r").readlines()) if cache_file.exists() else set()
 
 
 # Function to fetch and print search results


### PR DESCRIPTION
This pull request modifies KeyCrawler to automatically create the cache file and keys directory if they do not exist. Since this eliminates the need to create them manually, I have also modified the README to remove this step from the setup instructions.